### PR TITLE
update nuget.exe version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ##Release 1.0.11
  + Updated Nuget.exe from 3.3 to 4.1
+ + Fix ambiguous option 's' by specifying full name of argument
 
 ##Release 1.0.10
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+##Release 1.0.11
+ + Updated Nuget.exe from 3.3 to 4.1
+
 ##Release 1.0.10
 
  + Added support for excluding wildcard patterns when creating package.

--- a/Source/NuGet.Package.Builder/NuGet.Package.Builder.nuspec
+++ b/Source/NuGet.Package.Builder/NuGet.Package.Builder.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>NuGet.Package.Builder</id>
-		<version>1.0.10</version>
+		<version>1.0.11-pre02</version>
 		<title>NuGet Package Builder Tool</title>
 		<authors>Lars Skovslund</authors>
 		<owners>Lars Skovslund</owners>

--- a/Source/NuGet.Package.Builder/PackageOptions.cs
+++ b/Source/NuGet.Package.Builder/PackageOptions.cs
@@ -114,7 +114,7 @@ namespace NuGet.Package.Builder
 				: arguments.OverrideSource;
 
 			return !string.IsNullOrWhiteSpace(source)
-				? string.Format("-s {0}", source)
+				? string.Format("-Source {0}", source)
 				: string.Empty;
 		}
 
@@ -125,7 +125,7 @@ namespace NuGet.Package.Builder
                 : arguments.OverrideSymbolSource;
 
             return !string.IsNullOrWhiteSpace(source)
-                ? string.Format("-s {0}", source)
+                ? string.Format("-SymbolSource {0}", source)
                 : string.Empty;
         }
 


### PR DESCRIPTION
Hey,

I've updated the nuget.exe version as the current version causes some problems when specifying netstandard as targetframework for references.

Would you consider this pull request.

Thanks,

Stefaan.